### PR TITLE
Avoid java.lang.OutOfMemoryError

### DIFF
--- a/googlemapsanimations/src/main/java/com/arsy/maps_library/MapRadar.java
+++ b/googlemapsanimations/src/main/java/com/arsy/maps_library/MapRadar.java
@@ -67,6 +67,7 @@ public class MapRadar {
     private int colors[] = {Color.parseColor("#0038728f"), Color.parseColor("#ff38728f")};    //sweep animation colors
 
     public MapRadar(GoogleMap googleMap, LatLng latLng, Context context) {
+        System.gc();//Garbage collect here to avoid java.lang.OutOfMemoryError in some devices.
         this.googleMap = googleMap;
         this.latLng = latLng;
         this.prevlatlng = latLng;


### PR DESCRIPTION
Garbage collect on MapRadar object instantiation to avoid java.lang.OutOfMemoryError in some devices.

On Samsung galaxy-grand-prime-g530h (Android 4.4.4) testing had java.lang.OutOfMemoryError related to Bitmap functions (http://www.samsung.com/latin_en/smartphones/galaxy-grand-prime-g530h/).

On Samsung SM-T231 (Android 4.4.2) unmodified package worked as expected (http://www.samsung.com/ae/business/business-products/tablets/tablets/SM-T231NZWAXSG).